### PR TITLE
Fix import order

### DIFF
--- a/image_classifier.ipynb
+++ b/image_classifier.ipynb
@@ -31,11 +31,15 @@
     "import urllib\n",
     "import tarfile\n",
     "\n",
-    "import coremltools\n",
     "from skafossdk import *\n",
     "\n",
     "from utilities.load_turicreate import *\n",
-    "import utilities.save_models as sm"
+    "import utilities.save_models as sm\n",
+    "\n",
+    "# Check to make sure turicreate is installed\n",
+    "tc = install_turicreate(timeout=500, retries=2) \n",
+    "\n",
+    "import coremltools # Turi Create required prior to import\n"
    ]
   },
   {
@@ -44,7 +48,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tc = install_turicreate(timeout=500, retries=2) #check to make sure turicreate is installed\n",
     "ska  = Skafos() # initialize Skafos"
    ]
   },


### PR DESCRIPTION
Turi Create must be installed prior to importing `coremltools` to the notebook.