### PR TITLE
Gpu preparation

### DIFF
--- a/image_classifier.ipynb
+++ b/image_classifier.ipynb
@@ -114,7 +114,7 @@
     "### 2. **Build the model**\n",
     "We use the `tc.image_classifer.create` function and specify the data, target variable, and a few other arguments needed to properly train the model. To understand more about this specific function, check out the [Ture Create Documentation](https://apple.github.io/turicreate/docs/api/generated/turicreate.image_classifier.create.html#turicreate.image_classifier.create).\n",
     "\n",
-    "**We recommend training this model on a GPU instead of CPU.** [You can leverage a GPU by deploying this code as a job](https://dash.readme.io/project/metismachine/v1.3.1/docs/using-a-gpu)."
+    "**We recommend training this model on a GPU instead of CPU.** [You can leverage a GPU by deploying this code as a job](https://docs.metismachine.io/v1.3.1/docs/using-a-gpu)."
    ]
   },
   {

--- a/image_classifier.ipynb
+++ b/image_classifier.ipynb
@@ -114,7 +114,7 @@
     "### 2. **Build the model**\n",
     "We use the `tc.image_classifer.create` function and specify the data, target variable, and a few other arguments needed to properly train the model. To understand more about this specific function, check out the [Ture Create Documentation](https://apple.github.io/turicreate/docs/api/generated/turicreate.image_classifier.create.html#turicreate.image_classifier.create).\n",
     "\n",
-    "**Note: GPU support is coming soon. The code below has been commented out because it will take a long time (~90 mins) to train with CPUs. Additionally, if you don't update the training dataset, it will re-create the baseline image classification model from the integration guide on the Skafos dashboard.**"
+    "**We recommend training this model on a GPU instead of CPU.** [You can leverage a GPU by deploying this code as a job](https://dash.readme.io/project/metismachine/v1.3.1/docs/using-a-gpu)."
    ]
   },
   {
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "# Train an image classification model, specifying the name of the 'target'/'label' column\n",
-    "#model = tc.image_classifier.create(train_data, target='label')"
+    "model = tc.image_classifier.create(train_data, target='label')"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 skafossdk==1.2.2
-mxnet-cu80==1.1.0.post0
 turicreate==5.3.1
+mxnet==1.1.0
+mxnet-cu80==1.1.0
 coremltools==2.1.0
 numpy==1.16.1

--- a/utilities/dependencies.py
+++ b/utilities/dependencies.py
@@ -4,24 +4,24 @@ import sys
 from subprocess import check_output
 
 
-def _try_install(timeout):
+def _requirements(timeout):
     try:
-        # try installing, give it 3 mins to try and install 
+        # try installing, give it 3 mins to try and install
         output = check_output(["pip", "install", "-r", "/home/jovyan/requirements.txt"], timeout=timeout)
-        
     except Exception as e:
         print(f"Exception encountered while installing dependencies: {e}", flush=True)
         raise e
 
 def install(timeout=300, retries=2):
     # Install all dependencies inside requirements.txt
-    print("Checking and installing required python dependencies in requirements.txt", flush=True)
-    try:
-        _try_install(timeout)
-        # Load pkg directly from site-packages (avoid restart kernel)  
-        if not os.path.exists(".local/site-packages/"):
-            os.makedirs(".local/site-packages/")
-        sys.path.append(".local/site-packages/")
-    except Exception as e:
-        raise e
-    print("Done", flush=True)
+    if os.path.exists("/home/jovyan/"):
+        print("Checking and installing required python dependencies in requirements.txt", flush=True)
+        try:
+            _requirements(timeout)
+            # Load pkg directly from site-packages (avoid restart kernel)
+            if not os.path.exists(".local/site-packages/"):
+                os.makedirs(".local/site-packages/")
+            sys.path.append(".local/site-packages/")
+        except Exception as e:
+            raise e
+        print("Done", flush=True)


### PR DESCRIPTION
- updated requirements
- added comments to notebook
- updated dependency module


## Instructions for testing
1. Login to production Skafos dashboard.
2. Open up an existing Image Classifier project created not too long ago. OR create a new standard Image Classifier project from the dashboard.
3. Launch JLab.
4. Open Terminal and run the following to get the code to test:
```bash
$ git remote add origin https://github.com/skafos/TuriImageClassifier.git
$ git fetch origin
$ git reset --hard origin/master
$ git checkout gpu-prep
```
5. Open skafos JSON config and swap cpu/memory requests and limits to:
`"nvidia.com/gpu": 1`. Check config details here: https://docs.metismachine.io/v1.3.1/docs/using-a-gpu
6. Save config and hit deploy.
7. Job should run successfully and train a thing.